### PR TITLE
Fix padding on `#[long]` args in help text.

### DIFF
--- a/onlyargs_derive/src/lib.rs
+++ b/onlyargs_derive/src/lib.rs
@@ -413,12 +413,13 @@ fn to_help(view: ArgView, max_width: usize) -> String {
     let pad = " ".repeat(max_width + LONG_PAD);
     let help = view.doc.join(&format!("\n{pad}"));
 
+    let width = max_width - name.len();
     if let Some(ch) = view.short {
-        let width = max_width - SHORT_PAD - name.len();
+        let width = width - SHORT_PAD;
 
         format!("  -{ch} --{name}{ty:<width$}  {help}\n")
     } else {
-        format!("  --{name}{ty:<max_width$}  {help}\n")
+        format!("  --{name}{ty:<width$}  {help}\n")
     }
 }
 


### PR DESCRIPTION
Example before:

```
Flags:
  -h --help     Show this help message.
  -V --version  Show the application version.
  -v --verbose  Enable verbose output.

Options:
  --update-fpga PATH             Update FPGA Firmware.
  --update-wifi PATH             Update WiFi Firmware.
```

After:

```
Flags:
  -h --help     Show this help message.
  -V --version  Show the application version.
  -v --verbose  Enable verbose output.

Options:
  --update-fpga PATH  Update FPGA Firmware.
  --update-wifi PATH  Update WiFi Firmware.
```