### PR TITLE
Allow `let_underscore_untyped` lint

### DIFF
--- a/onlyargs_derive/src/lib.rs
+++ b/onlyargs_derive/src/lib.rs
@@ -100,6 +100,7 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
+#![allow(clippy::let_underscore_untyped)]
 
 use crate::parser::{ArgFlag, ArgOption, ArgType, ArgView, ArgumentStruct};
 use myn::utils::spanned_error;


### PR DESCRIPTION
This is far better than adding a pointless type annotation like `Result<_, _>`, and note the `#[must_use]` recommendation is adding `let _ =`.

This is a case where I just do not agree with `clippy::pedantic`.