### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "myn"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950af707b8005ae33bb0f0b20cb32b09750e7375085606dc45b2f2078a34e52"
+checksum = "531b2675eec9b104037d42e9045a0ea5c27c8727bdc8e1f55c93bb088f1dec07"
 
 [[package]]
 name = "onlyargs"
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "onlyerror"
-version = "0.1.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de62063c9f7ef82b259f3530af425d0b8bba375c7f790087616d8a613b5f8bc"
+checksum = "8c26d4ea2ccd9b7acedc478853805606e60c5b7b7aedfc1c54ed6d1fdc0587db"
 dependencies = [
  "myn",
 ]

--- a/onlyargs_derive/Cargo.toml
+++ b/onlyargs_derive/Cargo.toml
@@ -14,5 +14,5 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-myn = "0.1"
+myn = "0.2"
 onlyargs = { version = "0.1", path = ".." }


### PR DESCRIPTION
Updates `myn` to 0.2 and `onlyerror` to 0.1.4.

Fixes indentation on doc comments processed by `onlyargs_derive`.