### PR TITLE
Add footer attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "myn"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531b2675eec9b104037d42e9045a0ea5c27c8727bdc8e1f55c93bb088f1dec07"
+checksum = "51eb7addae0a5fbc6616160ee79bb7244eb644e2d18becf2f8f03603e06de63a"
 
 [[package]]
 name = "onlyargs"

--- a/examples/full-derive/src/main.rs
+++ b/examples/full-derive/src/main.rs
@@ -11,6 +11,10 @@ use std::{fmt::Write as _, path::PathBuf, process::ExitCode};
 /// A basic argument parsing example with `onlyargs_derive`.
 /// Sums a list of numbers and writes the result to a file or standard output.
 #[derive(Clone, Debug, Eq, PartialEq, OnlyArgs)]
+#[footer = "Please consider becoming a sponsor 💖:"]
+#[footer = "  - https://github.com/sponsors/parasyte"]
+#[footer = "  - https://ko-fi.com/blipjoy"]
+#[footer = "  - https://patreon.com/blipjoy"]
 struct Args {
     /// Your username.
     username: String,

--- a/onlyargs_derive/Cargo.toml
+++ b/onlyargs_derive/Cargo.toml
@@ -14,5 +14,5 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-myn = "0.2"
+myn = "0.2.1"
 onlyargs = { version = "0.1", path = ".." }

--- a/onlyargs_derive/src/parser.rs
+++ b/onlyargs_derive/src/parser.rs
@@ -8,6 +8,7 @@ pub(crate) struct ArgumentStruct {
     pub(crate) options: Vec<ArgOption>,
     pub(crate) positional: Option<ArgOption>,
     pub(crate) doc: Vec<String>,
+    pub(crate) footer: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -87,6 +88,11 @@ impl ArgumentStruct {
             .map(trim_with_indent)
             .collect();
 
+        let footer = get_attr_strings(&attrs, "footer")
+            .into_iter()
+            .map(|line| line.trim_end().to_string())
+            .collect();
+
         match input.next() {
             None => Ok(Self {
                 name,
@@ -94,6 +100,7 @@ impl ArgumentStruct {
                 options,
                 positional,
                 doc,
+                footer,
             }),
             tree => Err(spanned_error("Unexpected token", tree.as_span())),
         }


### PR DESCRIPTION
Provides a way to add extra context to the bottom of the help message.
The doc comment appears at the top, and `#[footer = "..."]` is a nice complement.