### PR TITLE
Normalize help messages in examples

### DIFF
--- a/examples/full-derive/src/main.rs
+++ b/examples/full-derive/src/main.rs
@@ -12,9 +12,9 @@ use std::{fmt::Write as _, path::PathBuf, process::ExitCode};
 /// Sums a list of numbers and writes the result to a file or standard output.
 #[derive(Clone, Debug, Eq, PartialEq, OnlyArgs)]
 #[footer = "Please consider becoming a sponsor 💖:"]
-#[footer = "  - https://github.com/sponsors/parasyte"]
-#[footer = "  - https://ko-fi.com/blipjoy"]
-#[footer = "  - https://patreon.com/blipjoy"]
+#[footer = "  * https://github.com/sponsors/parasyte"]
+#[footer = "  * https://ko-fi.com/blipjoy"]
+#[footer = "  * https://patreon.com/blipjoy"]
 struct Args {
     /// Your username.
     username: String,

--- a/examples/full/src/main.rs
+++ b/examples/full/src/main.rs
@@ -33,6 +33,10 @@ impl OnlyArgs for Args {
         "  -w --width NUMBER     Set the width. [default: 42]\n",
         "\nNumbers:\n",
         "  A list of numbers to sum.\n",
+        "\nPlease consider becoming a sponsor 💖:\n",
+        "  * https://github.com/sponsors/parasyte\n",
+        "  * https://ko-fi.com/blipjoy\n",
+        "  * https://patreon.com/blipjoy\n",
     );
 
     const VERSION: &'static str = onlyargs::impl_version!();

--- a/onlyargs_derive/src/lib.rs
+++ b/onlyargs_derive/src/lib.rs
@@ -178,7 +178,7 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
     let positional_help = ast
         .positional
         .as_ref()
-        .map(|opt| format!("\n{}:\n  {}", opt.name, opt.doc.join("\n  ")))
+        .map(|opt| format!("\n{}:\n  {}\n", opt.name, opt.doc.join("\n  ")))
         .unwrap_or_default();
 
     // Produce variables for argument parser state.
@@ -330,7 +330,7 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
     let footer = if ast.footer.is_empty() {
         String::new()
     } else {
-        format!("\n\n{}\n", ast.footer.join("\n"))
+        format!("\n{}\n", ast.footer.join("\n"))
     };
     let bin_name = std::env::var_os("CARGO_BIN_NAME").and_then(|name| name.into_string().ok());
     let help_impl = if bin_name.is_none() {
@@ -370,7 +370,6 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
                     {options_help:?},
                     {positional_help:?},
                     {footer:?},
-                    "\n",
                 );
 
                 const VERSION: &'static str = concat!(


### PR DESCRIPTION
This makes `onlyargs_derive` output only a single blank line at the end of the help message instead of two (which was characteristic of the previous release). Now the output is closer between the manual trait implementation and the derived trait impl.

Also changes the unordered list in the footer to use asterisks, which looks a bit better in ASCII and disambiguates between flags and options.