### PR TITLE
Fix defaults in onlyargs_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "basic-toml"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "error-iter"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,10 +45,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
 name = "myn"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51eb7addae0a5fbc6616160ee79bb7244eb644e2d18becf2f8f03603e06de63a"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "onlyargs"
@@ -54,6 +81,7 @@ version = "0.1.3"
 dependencies = [
  "myn",
  "onlyargs",
+ "trybuild",
 ]
 
 [[package]]
@@ -64,3 +92,130 @@ checksum = "8c26d4ea2ccd9b7acedc478853805606e60c5b7b7aedfc1c54ed6d1fdc0587db"
 dependencies = [
  "myn",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "serde"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9d3ba662913483d6722303f619e75ea10b7855b0f8e0d72799cf8621bb488f"
+dependencies = [
+ "basic-toml",
+ "glob",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/onlyargs_derive/Cargo.toml
+++ b/onlyargs_derive/Cargo.toml
@@ -13,6 +13,13 @@ license = "MIT"
 [lib]
 proc-macro = true
 
+[[test]]
+name = "compile_and_fail"
+path = "compile_tests/compiler.rs"
+
 [dependencies]
 myn = "0.2.1"
 onlyargs = { version = "0.1", path = ".." }
+
+[dev-dependencies]
+trybuild = "1"

--- a/onlyargs_derive/compile_tests/compiler.rs
+++ b/onlyargs_derive/compile_tests/compiler.rs
@@ -1,0 +1,41 @@
+#[test]
+fn compile_tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("compile_tests/default_bool_false.rs");
+    t.pass("compile_tests/default_bool_true.rs");
+    t.pass("compile_tests/default_f32.rs");
+    t.pass("compile_tests/default_f64.rs");
+    t.pass("compile_tests/default_i8.rs");
+    t.pass("compile_tests/default_i128.rs");
+    t.pass("compile_tests/default_isize.rs");
+    // TODO: Negatives are not supported yet!
+    // t.pass("compile_tests/default_negative_i8.rs");
+    // t.pass("compile_tests/default_negative_i128.rs");
+    // t.pass("compile_tests/default_negative_isize.rs");
+    t.pass("compile_tests/default_osstring.rs");
+    t.pass("compile_tests/default_pathbuf.rs");
+    t.pass("compile_tests/default_string.rs");
+    t.pass("compile_tests/default_u8.rs");
+    t.pass("compile_tests/default_u128.rs");
+    t.pass("compile_tests/default_usize.rs");
+
+    t.pass("compile_tests/positional_f32.rs");
+    t.pass("compile_tests/positional_f64.rs");
+    t.pass("compile_tests/positional_i8.rs");
+    t.pass("compile_tests/positional_i128.rs");
+    t.pass("compile_tests/positional_isize.rs");
+    t.pass("compile_tests/positional_osstring.rs");
+    t.pass("compile_tests/positional_pathbuf.rs");
+    t.pass("compile_tests/positional_string.rs");
+    t.pass("compile_tests/positional_u8.rs");
+    t.pass("compile_tests/positional_usize.rs");
+
+    t.pass("compile_tests/empty.rs");
+    t.pass("compile_tests/optional.rs");
+    t.pass("compile_tests/struct_doc_comment.rs");
+    t.pass("compile_tests/struct_footer.rs");
+
+    t.compile_fail("compile_tests/conflicting_short_name.rs");
+    t.pass("compile_tests/manual_short_name.rs");
+    t.pass("compile_tests/ignore_short_name.rs");
+}

--- a/onlyargs_derive/compile_tests/conflicting_short_name.rs
+++ b/onlyargs_derive/compile_tests/conflicting_short_name.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    min: i32,
+    max: i32,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/conflicting_short_name.stderr
+++ b/onlyargs_derive/compile_tests/conflicting_short_name.stderr
@@ -1,0 +1,5 @@
+error: Only one short arg is allowed. `-m` also used on field `min`
+ --> compile_tests/conflicting_short_name.rs:4:5
+  |
+4 |     max: i32,
+  |     ^^^

--- a/onlyargs_derive/compile_tests/default_bool_false.rs
+++ b/onlyargs_derive/compile_tests/default_bool_false.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(false)]
+    maybe: bool,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_bool_true.rs
+++ b/onlyargs_derive/compile_tests/default_bool_true.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(true)]
+    maybe: bool,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_f32.rs
+++ b/onlyargs_derive/compile_tests/default_f32.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(42.123)]
+    width: f32,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_f64.rs
+++ b/onlyargs_derive/compile_tests/default_f64.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(42.123)]
+    width: f64,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_i128.rs
+++ b/onlyargs_derive/compile_tests/default_i128.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(42)]
+    width: i128,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_i8.rs
+++ b/onlyargs_derive/compile_tests/default_i8.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(42)]
+    width: i8,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_isize.rs
+++ b/onlyargs_derive/compile_tests/default_isize.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(42)]
+    width: isize,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_negative_i128.rs
+++ b/onlyargs_derive/compile_tests/default_negative_i128.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(-42)]
+    width: i128,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_negative_i8.rs
+++ b/onlyargs_derive/compile_tests/default_negative_i8.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(-42)]
+    width: i8,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_negative_isize.rs
+++ b/onlyargs_derive/compile_tests/default_negative_isize.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(-42)]
+    width: isize,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_osstring.rs
+++ b/onlyargs_derive/compile_tests/default_osstring.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default("foo bar")]
+    name: std::ffi::OsString,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_pathbuf.rs
+++ b/onlyargs_derive/compile_tests/default_pathbuf.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default("./foo/bar")]
+    path: std::path::PathBuf,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_string.rs
+++ b/onlyargs_derive/compile_tests/default_string.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default("foo bar")]
+    name: String,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_u128.rs
+++ b/onlyargs_derive/compile_tests/default_u128.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(42)]
+    width: u128,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_u8.rs
+++ b/onlyargs_derive/compile_tests/default_u8.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(42)]
+    width: u8,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/default_usize.rs
+++ b/onlyargs_derive/compile_tests/default_usize.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[default(42)]
+    width: usize,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/empty.rs
+++ b/onlyargs_derive/compile_tests/empty.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/ignore_short_name.rs
+++ b/onlyargs_derive/compile_tests/ignore_short_name.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    min: i32,
+
+    #[long]
+    max: i32,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/manual_short_name.rs
+++ b/onlyargs_derive/compile_tests/manual_short_name.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    min: i32,
+
+    #[short('x')]
+    max: i32,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/optional.rs
+++ b/onlyargs_derive/compile_tests/optional.rs
@@ -1,0 +1,39 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    #[long]
+    opt_f32: Option<f32>,
+    #[long]
+    opt_f64: Option<f64>,
+    #[long]
+    opt_i8: Option<i8>,
+    #[long]
+    opt_i16: Option<i16>,
+    #[long]
+    opt_i32: Option<i32>,
+    #[long]
+    opt_i64: Option<i64>,
+    #[long]
+    opt_i128: Option<i128>,
+    #[long]
+    opt_isize: Option<isize>,
+    #[long]
+    opt_u8: Option<u8>,
+    #[long]
+    opt_u16: Option<u16>,
+    #[long]
+    opt_u32: Option<u32>,
+    #[long]
+    opt_u64: Option<u64>,
+    #[long]
+    opt_u128: Option<u128>,
+    #[long]
+    opt_usize: Option<usize>,
+    #[long]
+    opt_osstring: Option<std::ffi::OsString>,
+    #[long]
+    opt_path: Option<std::path::PathBuf>,
+    #[long]
+    opt_string: Option<String>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_f32.rs
+++ b/onlyargs_derive/compile_tests/positional_f32.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<f32>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_f64.rs
+++ b/onlyargs_derive/compile_tests/positional_f64.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<f64>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_i128.rs
+++ b/onlyargs_derive/compile_tests/positional_i128.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<i128>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_i8.rs
+++ b/onlyargs_derive/compile_tests/positional_i8.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<i8>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_isize.rs
+++ b/onlyargs_derive/compile_tests/positional_isize.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<isize>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_osstring.rs
+++ b/onlyargs_derive/compile_tests/positional_osstring.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<std::ffi::OsString>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_pathbuf.rs
+++ b/onlyargs_derive/compile_tests/positional_pathbuf.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<std::path::PathBuf>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_string.rs
+++ b/onlyargs_derive/compile_tests/positional_string.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<String>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_u128.rs
+++ b/onlyargs_derive/compile_tests/positional_u128.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<u128>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_u8.rs
+++ b/onlyargs_derive/compile_tests/positional_u8.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<u8>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/positional_usize.rs
+++ b/onlyargs_derive/compile_tests/positional_usize.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+struct Args {
+    rest: Vec<usize>,
+}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/struct_doc_comment.rs
+++ b/onlyargs_derive/compile_tests/struct_doc_comment.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+/// Doc comment message
+struct Args {}
+
+fn main() {}

--- a/onlyargs_derive/compile_tests/struct_footer.rs
+++ b/onlyargs_derive/compile_tests/struct_footer.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, onlyargs_derive::OnlyArgs)]
+#[footer = "Footer message"]
+struct Args {}
+
+fn main() {}

--- a/onlyargs_derive/src/lib.rs
+++ b/onlyargs_derive/src/lib.rs
@@ -241,27 +241,27 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
         let name = &opt.name;
         let short = opt
             .short
-            .map(|ch| format!(r#"| Some(name @ "-{ch}")"#))
+            .map(|ch| format!(r#"| Some(arg_name_ @ "-{ch}")"#))
             .unwrap_or_default();
         let value = if opt.default.is_some() {
             match opt.ty_help {
-                ArgType::Number => "args.next().parse_int(name)?",
-                ArgType::OsString => "args.next().parse_osstr(name)?",
-                ArgType::Path => "args.next().parse_path(name)?",
-                ArgType::String => "args.next().parse_str(name)?",
+                ArgType::Number => "args.next().parse_int(arg_name_)?",
+                ArgType::OsString => "args.next().parse_osstr(arg_name_)?",
+                ArgType::Path => "args.next().parse_path(arg_name_)?",
+                ArgType::String => "args.next().parse_str(arg_name_)?",
             }
         } else {
             match opt.ty_help {
-                ArgType::Number => "Some(args.next().parse_int(name)?)",
-                ArgType::OsString => "Some(args.next().parse_osstr(name)?)",
-                ArgType::Path => "Some(args.next().parse_path(name)?)",
-                ArgType::String => "Some(args.next().parse_str(name)?)",
+                ArgType::Number => "Some(args.next().parse_int(arg_name_)?)",
+                ArgType::OsString => "Some(args.next().parse_osstr(arg_name_)?)",
+                ArgType::Path => "Some(args.next().parse_path(arg_name_)?)",
+                ArgType::String => "Some(args.next().parse_str(arg_name_)?)",
             }
         };
 
         write!(
             matchers,
-            r#"Some(name @ "--{arg}") {short} => {name} = {value},"#,
+            r#"Some(arg_name_ @ "--{arg}") {short} => {name} = {value},"#,
             arg = to_arg_name(name)
         )
         .unwrap();

--- a/onlyargs_derive/src/lib.rs
+++ b/onlyargs_derive/src/lib.rs
@@ -89,7 +89,7 @@
 //! | `String`         | UTF-8 encoded string option.                     |
 //!
 //! Additionally, some wrapper and composite types are also available, where the type `T` must be
-//! one of the primitive types listed above.
+//! one of the primitive types listed above (except `bool`).
 //!
 //! | Type        | Description                       |
 //! |-------------|-----------------------------------|

--- a/onlyargs_derive/src/lib.rs
+++ b/onlyargs_derive/src/lib.rs
@@ -245,14 +245,16 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
             .unwrap_or_default();
         let value = if opt.default.is_some() {
             match opt.ty_help {
-                ArgType::Number => "args.next().parse_int(arg_name_)?",
+                ArgType::Float => "args.next().parse_float(arg_name_)?",
+                ArgType::Integer => "args.next().parse_int(arg_name_)?",
                 ArgType::OsString => "args.next().parse_osstr(arg_name_)?",
                 ArgType::Path => "args.next().parse_path(arg_name_)?",
                 ArgType::String => "args.next().parse_str(arg_name_)?",
             }
         } else {
             match opt.ty_help {
-                ArgType::Number => "Some(args.next().parse_int(arg_name_)?)",
+                ArgType::Float => "Some(args.next().parse_float(arg_name_)?)",
+                ArgType::Integer => "Some(args.next().parse_int(arg_name_)?)",
                 ArgType::OsString => "Some(args.next().parse_osstr(arg_name_)?)",
                 ArgType::Path => "Some(args.next().parse_path(arg_name_)?)",
                 ArgType::String => "Some(args.next().parse_str(arg_name_)?)",
@@ -271,7 +273,8 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
         Some(opt) => {
             let name = &opt.name;
             let value = match opt.ty_help {
-                ArgType::Number => r#"arg.parse_int("<POSITIONAL>")?"#,
+                ArgType::Float => r#"arg.parse_float("<POSITIONAL>")?"#,
+                ArgType::Integer => r#"arg.parse_int("<POSITIONAL>")?"#,
                 ArgType::OsString => r#"arg.parse_osstr("<POSITIONAL>")?"#,
                 ArgType::Path => r#"arg.parse_path("<POSITIONAL>")?"#,
                 ArgType::String => r#"arg.parse_str("<POSITIONAL>")?"#,

--- a/onlyargs_derive/src/lib.rs
+++ b/onlyargs_derive/src/lib.rs
@@ -202,7 +202,7 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
         .map(|opt| {
             let name = &opt.name;
             if let Some(default) = opt.default.as_ref() {
-                format!("let mut {name} = {default}.into();")
+                format!("let mut {name} = {default}{};", opt.ty_help.converter())
             } else {
                 format!("let mut {name} = None;")
             }

--- a/onlyargs_derive/src/parser.rs
+++ b/onlyargs_derive/src/parser.rs
@@ -389,6 +389,13 @@ impl ArgType {
             Self::Path => " PATH",
         }
     }
+
+    pub(crate) fn converter(&self) -> &str {
+        match self {
+            Self::Number => "",
+            Self::OsString | Self::Path | Self::String => ".into()",
+        }
+    }
 }
 
 #[allow(clippy::needless_pass_by_value)]


### PR DESCRIPTION
- Fixes default for floats and integers.
- Fixes struct fields named `name` (just don't name your field `arg_name_` and you'll be ok).
- Adds regression tests.