### PR TITLE
Fix required positional arguments

### DIFF
--- a/onlyargs_derive/Cargo.toml
+++ b/onlyargs_derive/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["command-line-interface"]
 license = "MIT"
 exclude = [
     "/compile_tests",
+    "/tests",
 ]
 
 [lib]

--- a/onlyargs_derive/src/lib.rs
+++ b/onlyargs_derive/src/lib.rs
@@ -357,7 +357,18 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
         .collect::<String>();
     let positional_ident = ast
         .positional
-        .map(|opt| format!("{},", opt.name))
+        .map(|opt| {
+            if matches!(opt.property, ArgProperty::Positional { required: true }) {
+                format!(
+                    r#"{}: {}.required("{arg}")?,"#,
+                    opt.name,
+                    opt.name,
+                    arg = to_arg_name(&opt.name),
+                )
+            } else {
+                format!("{},", opt.name)
+            }
+        })
         .unwrap_or_default();
 
     let name = ast.name;

--- a/onlyargs_derive/tests/parsing.rs
+++ b/onlyargs_derive/tests/parsing.rs
@@ -84,3 +84,26 @@ fn test_required_multivalue() -> Result<(), CliError> {
 
     Ok(())
 }
+
+#[test]
+fn test_required_positional() -> Result<(), CliError> {
+    #[derive(Debug, OnlyArgs)]
+    struct Args {
+        #[required]
+        #[positional]
+        rest: Vec<String>,
+    }
+
+    // Empty positional is not allowed.
+    assert!(matches!(
+        dbg!(Args::parse(vec![])),
+        Err(CliError::MissingRequired(name)) if name == "rest",
+    ));
+
+    // At least one positional is required.
+    let args = Args::parse(["Bob"].into_iter().map(OsString::from).collect())?;
+
+    assert_eq!(args.rest, ["Bob"]);
+
+    Ok(())
+}


### PR DESCRIPTION
`#[required]` and `#[positional]` can be used together.